### PR TITLE
Add missing window.__RUNTIME__ data to runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.1] - 2020-06-23
 ### Fixed
 - Add global `__RUNTIME__` data local `runtime`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add global `__RUNTIME__` data local `runtime`.
 
 ## [0.2.0] - 2019-12-19
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/render-extension-loader",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "VTEX IO Render Extension Loader",
   "main": "lib/render-extension-loader.js",
   "browser": "lib/render-extension-loader.js",

--- a/src/render-extension-loader.ts
+++ b/src/render-extension-loader.ts
@@ -142,6 +142,12 @@ class RenderExtensionLoader {
     )
     this.timeEnd('render-extension-loader:json')
 
+    for (const key in window.__RUNTIME__ || {}) {
+      if (window.__RUNTIME__.hasOwnProperty(key) && runtime[key] === undefined) {
+        runtime[key] = window.__RUNTIME__[key]
+      }
+    }
+
     this.setGlobalContext({ runtime, styles, scripts })
     return { runtime, styles, scripts }
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add missing `window.__RUNTIME__` data to `runtime`

#### What problem is this solving?
There is a global `__RUNTIME__` included in the /checkout HTML when the
store has root path:

Ex:
```
<script>
window.__RUNTIME__ = window.__RUNTIME__ || {account:"motorolaus", workspace:"master"};
window.__RUNTIME__.rootPath="/us";
</script>
```

But this information is not available on the `runtime` fetched with
render-extension-loader.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
